### PR TITLE
Allow importing into other Go projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 
 NAME:=$(notdir $(CURDIR))
 VERSION:=$(shell git describe --tags 2>$(NUL) || echo v0.0.0)
-GOOPT:=-ldflags "-s -w -X main.version=$(VERSION)"
+GOOPT:=-ldflags "-s -w -X core.version=$(VERSION)"
 EXE:=$(shell go env GOEXE)
 
 all:

--- a/core/embed.go
+++ b/core/embed.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/hymkor/gmnlisp"
+)
+
+// version is set by Makefile, thus it is not compatible with
+// RunEmbedded unless handled by the downstream developer.
+var version string
+
+func RunEmbedded(script string, additionalArgs []string) {
+	if err := mains(append([]string{script}, additionalArgs...), true); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func Run() {
+	if err := mains(os.Args[1:], false); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func mains(args []string, embedded bool) error {
+	term, err := NewTerm()
+	if err != nil {
+		return err
+	}
+	defer term.Close()
+
+	watcher := NewWatcher(term)
+
+	g := &Global{
+		term: term,
+		w:    watcher,
+	}
+	defer g.Close()
+
+	gmnlisp.NewLineOnFormat = []byte{'\r', '\n'}
+
+	lisp := gmnlisp.New()
+
+	lisp = lisp.Flet(
+		gmnlisp.Functions{
+			gmnlisp.NewSymbol("send"):    &gmnlisp.Function{Min: 1, F: g.send},
+			gmnlisp.NewSymbol("sendln"):  &gmnlisp.Function{Min: 1, F: g.sendln},
+			gmnlisp.NewSymbol("spawn"):   &gmnlisp.Function{Min: 1, F: g.spawn},
+			gmnlisp.NewSymbol("expect*"): gmnlisp.SpecialF(g.expectX),
+			gmnlisp.NewSymbol("expect"):  gmnlisp.SpecialF(g.expect),
+			gmnlisp.NewSymbol("getenv"):  gmnlisp.Function1(g.getenv),
+			gmnlisp.NewSymbol("setenv"):  gmnlisp.Function2(g.setenv),
+			gmnlisp.NewSymbol("wait"):    gmnlisp.Function1(g.wait),
+		})
+
+	if len(args) <= 0 {
+		return fmt.Errorf("%s %s-%s-%s: script path required",
+			os.Args[0],
+			version,
+			runtime.GOOS,
+			runtime.GOARCH)
+	}
+	var script []byte
+	if !embedded {
+		script, err = os.ReadFile(args[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		script = []byte(args[0])
+	}
+
+	posixArgv := []gmnlisp.Node{}
+	for _, s := range args[1:] {
+		posixArgv = append(posixArgv, gmnlisp.String(s))
+	}
+	executable := os.Args[0]
+	if value, err := os.Executable(); err == nil {
+		executable = value
+	}
+	lisp = lisp.Let(gmnlisp.Variables{
+		gmnlisp.NewSymbol("ARGV"):            gmnlisp.List(posixArgv...),
+		gmnlisp.NewSymbol("PROGRAM-NAME"):    gmnlisp.String(args[0]),
+		gmnlisp.NewSymbol("EXECUTABLE-NAME"): gmnlisp.String(executable),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_, err = lisp.Interpret(ctx, string(script))
+	cancel()
+	return err
+}

--- a/core/global.go
+++ b/core/global.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"context"

--- a/core/term.go
+++ b/core/term.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"os"

--- a/core/watcher.go
+++ b/core/watcher.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"io"

--- a/main.go
+++ b/main.go
@@ -1,82 +1,9 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"runtime"
-
-	"github.com/hymkor/gmnlisp"
+	"github.com/hymkor/lispect/core"
 )
 
-var version string
-
-func mains(args []string) error {
-	term, err := NewTerm()
-	if err != nil {
-		return err
-	}
-	defer term.Close()
-
-	watcher := NewWatcher(term)
-
-	g := &Global{
-		term: term,
-		w:    watcher,
-	}
-	defer g.Close()
-
-	gmnlisp.NewLineOnFormat = []byte{'\r', '\n'}
-
-	lisp := gmnlisp.New()
-
-	lisp = lisp.Flet(
-		gmnlisp.Functions{
-			gmnlisp.NewSymbol("send"):    &gmnlisp.Function{Min: 1, F: g.send},
-			gmnlisp.NewSymbol("sendln"):  &gmnlisp.Function{Min: 1, F: g.sendln},
-			gmnlisp.NewSymbol("spawn"):   &gmnlisp.Function{Min: 1, F: g.spawn},
-			gmnlisp.NewSymbol("expect*"): gmnlisp.SpecialF(g.expectX),
-			gmnlisp.NewSymbol("expect"):  gmnlisp.SpecialF(g.expect),
-			gmnlisp.NewSymbol("getenv"):  gmnlisp.Function1(g.getenv),
-			gmnlisp.NewSymbol("setenv"):  gmnlisp.Function2(g.setenv),
-			gmnlisp.NewSymbol("wait"):    gmnlisp.Function1(g.wait),
-		})
-
-	if len(args) <= 0 {
-		return fmt.Errorf("%s %s-%s-%s: script path required",
-			os.Args[0],
-			version,
-			runtime.GOOS,
-			runtime.GOARCH)
-	}
-	script, err := os.ReadFile(args[0])
-	if err != nil {
-		return err
-	}
-
-	posixArgv := []gmnlisp.Node{}
-	for _, s := range args[1:] {
-		posixArgv = append(posixArgv, gmnlisp.String(s))
-	}
-	executable := os.Args[0]
-	if value, err := os.Executable(); err == nil {
-		executable = value
-	}
-	lisp = lisp.Let(gmnlisp.Variables{
-		gmnlisp.NewSymbol("ARGV"):            gmnlisp.List(posixArgv...),
-		gmnlisp.NewSymbol("PROGRAM-NAME"):    gmnlisp.String(args[0]),
-		gmnlisp.NewSymbol("EXECUTABLE-NAME"): gmnlisp.String(executable),
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	_, err = lisp.Interpret(ctx, string(script))
-	cancel()
-	return err
-}
-
 func main() {
-	if err := mains(os.Args[1:]); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
+	core.Run()
 }


### PR DESCRIPTION
This PR splits lispect into two packages to allow importing and using it as a module in other Go projects.

For work, I needed to add a feature to a Go CLI app that does some CLI automation. Lispect works great, but I need to be able to share my program with colleagues without requiring them to install any external dependencies.

Luckily, lispect was written in a way where all that is needed to allow it to be used as a Go module is to split the core functionality out of the `main` package.

If you find any part of this PR suboptimal, please let me know! The way I've implemented it should have zero impact on the previous intended functionality of lispect as a standalone program.